### PR TITLE
Adding support and documentation for explicit joins

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -182,6 +182,8 @@ Specifying a non-numeric `id` attribute to the `[ux_cv_api4_get]` shortcode inst
 
 Implicit joins using Api4 are supported, e.g. `[api4:loc_block_id.address_id.street_address]`
 
+Simple explicit joins are supported by adding `join=EntityName:EntityAlias:JoinType:LeftJoinField:JoinCondition:RightJoinField`, for example for a join of individual contacts onto their organisations `join=Contact:contact:INNER:organization_name:=:contact.display_name`. All fields of the joined contacts will be available at `contact.*`. Details of allowed values for each field can be found using the API explorer. Joins using entity bridges are currently not supported.
+
 Multi-value fields are output as a comma separated list where possible.
 
 Limited format support is available:

--- a/shortcodes/civicrm/api4-get.php
+++ b/shortcodes/civicrm/api4-get.php
@@ -71,6 +71,14 @@ class Civicrm_Ux_Shortcode_CiviCRM_Api4_Get extends Abstract_Civicrm_Ux_Shortcod
 					}
 					$params['orderBy'][ $sort ] = $dir;
 					break;
+				case 'join':
+					[ $join_entity, $alias, $join_type, $left_field, $condition, $right_field ] = explode( ':', $v, 6);
+					$params['join'][] = [
+						$join_entity . ' AS ' . $alias,
+						$join_type,
+						[$left_field, $condition, $right_field],
+					];
+					break;
 				default:
 					[ $op, $value ] = explode( ':', $v, 2 );
 					if ( ! $value ) {
@@ -109,11 +117,14 @@ class Civicrm_Ux_Shortcode_CiviCRM_Api4_Get extends Abstract_Civicrm_Ux_Shortcod
 		$params = apply_filters( $this->get_shortcode_name() . '/params', $params, $atts );
 
 		if ($atts['entity'] == 'Contact') {
-			$params['join'] = [
-				['Email AS email', 'LEFT', ['email.is_primary', '=', TRUE]],
-				['Address AS address', 'LEFT', ['address.is_primary', '=', TRUE]],
-				['Phone AS phone', 'LEFT', ['phone.is_primary', '=', TRUE]],
-			];
+			if (!isset($params['join'])) {
+                $params['join'] = array();
+            }
+            array_push($params['join'],
+                ['Email AS email', 'LEFT', ['email.is_primary', '=', TRUE]],
+                ['Address AS address', 'LEFT', ['address.is_primary', '=', TRUE]],
+                ['Phone AS phone', 'LEFT', ['phone.is_primary', '=', TRUE]],
+            );
 		}
 
 		try {


### PR DESCRIPTION
Adding support for explicit joins to the `ux_cv_api4_get` shortcode with documentation.

Uses a `join=EntityName:EntityAlias:JoinType:LeftJoinField:JoinCondition:RightJoinField` syntax as a shortcode argument.