### PR TITLE
Feature: Text formatting based on string length

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -189,6 +189,7 @@ Limited format support is available:
 * Date fields can have their format specified with the same format as [CiviCRM's date display](https://docs.civicrm.org/user/en/latest/initial-set-up/dates/), e.g. `[api4:start_date:%B %E, %Y]`
 * File upload fields can be output as images with width, height, and alt text specified, e.g. `[api4:My_Custom_Field_Group.Image_Upload:img:800x300:alt=A picture]`
 * A line break tag can be output with fields only when they contain data with `:br`, e.g. `[api4:My_Custom_Field_Group.Optional_Field:br]`
+* Text fields may be truncated at a certain length using `[api4:title:100:chars:...]`, where the `chars` may be replaced by `words`. The `...` argument is optional, and will be added to the end of truncated strings.
 
 ### CiviCRM API trouble-shooting
 

--- a/shortcodes/civicrm/api4-get.php
+++ b/shortcodes/civicrm/api4-get.php
@@ -146,6 +146,16 @@ class Civicrm_Ux_Shortcode_CiviCRM_Api4_Get extends Abstract_Civicrm_Ux_Shortcod
 
 					if ( ( $field['data_type'] == 'Date' ) || ( $field['data_type'] == 'Timestamp' ) ) {
 						$output = isset( $match['format'] ) ? strftime( $match['format'], strtotime( $output ) ) : CRM_Utils_Date::customFormat( $output );
+					} elseif ( ( $field['data_type'] == 'String' ) || ( $field['data_type'] == 'Text' ) ) {
+						if ( preg_match( '/(?<len>\d+):(?<cw>chars|words):?(?<end>.*)/x' , $match['format'], $m ) ) {
+							if ( ( $m['cw'] == 'words' ) && ( $m['len'] < str_word_count($output) ) ) {
+								$output = implode( ' ', array_slice( explode( ' ', $output), 0, $m['len'] ) );
+								$output .= $m['end'];
+							} elseif ( $m['len'] < strlen($output) ) {
+								$output = substr( $output, 0, $m['len'] );
+								$output .= $m['end'];
+							}
+						}
 					} elseif ( $field['fk_entity'] == 'File' ) {
 						$output = Civicrm_Ux::in_basepage( function () use ( $output ) {
 							return htmlentities( civicrm_api3( 'Attachment', 'getvalue', [


### PR DESCRIPTION
Adds formatting options for text fields to the `ux_cv_api4_get` shortcode to truncate the string returned to a certain word/character length.