### PR TITLE
Improving integer parsing for url parameters

### DIFF
--- a/shortcodes/civicrm/api4-get.php
+++ b/shortcodes/civicrm/api4-get.php
@@ -29,7 +29,7 @@ class Civicrm_Ux_Shortcode_CiviCRM_Api4_Get extends Abstract_Civicrm_Ux_Shortcod
 			];
 
 		// If "id" attribute exists but isn't an integer, replace it with a GET parameter with that name.
-		if ( array_key_exists( 'id', $atts ) && ! is_int( $atts['id'] ) && preg_match('{^ (?![_-]) [A-Za-z0-9_-]+ $}x', $atts['id']) ) {
+		if ( array_key_exists( 'id', $atts ) && ( filter_var($atts['id'], FILTER_VALIDATE_INT) === false ) && preg_match('{^ (?![_-]) [A-Za-z0-9_-]+ $}x', $atts['id']) ) {
 			$atts['id'] = (int) $_GET[ $atts['id'] ];
 			if ( $atts['id'] < 1 ) {
 				return __( 'Invalid ID' );

--- a/shortcodes/civicrm/api4-get.php
+++ b/shortcodes/civicrm/api4-get.php
@@ -117,7 +117,7 @@ class Civicrm_Ux_Shortcode_CiviCRM_Api4_Get extends Abstract_Civicrm_Ux_Shortcod
 		}
 
 		try {
-			$trkey = $this->get_shortcode_name() . '__' . md5( $atts['entity'] . ':get:' . json_encode( $params ) );
+			$trkey = $this->get_shortcode_name() . '__' . md5( $atts['entity'] . ':get:' . json_encode( $params ) . $content );
 
 			$all = get_transient( $trkey );
 


### PR DESCRIPTION
Sometimes, the id parameter is passed into the `[ux_cv_api4_get]` as a string, and in this case the `is_int` check fails, making it impossible to retrieve a specific result.

The new check uses the `FILTER_VALIDATE_INT` filter, which will correctly categorize integer strings, but can falsely validate some decimal strings as integers.

This one is probably an improvement, as it covers all of the common cases (providing an integer or providing a word), but there might be a more consistent way of validating integers and integer strings.