### PR TITLE
Adding additional shortcode characters

### DIFF
--- a/shortcodes/civicrm/api4-get.php
+++ b/shortcodes/civicrm/api4-get.php
@@ -100,7 +100,7 @@ class Civicrm_Ux_Shortcode_CiviCRM_Api4_Get extends Abstract_Civicrm_Ux_Shortcod
 
 		$match = [];
 
-		$output_regex = '/ (?: ( \[ ) | ( {{ ) ) api4: (?<field> [^][[:space:]:{}]+ (?::(?:label|value|name|id))?) (?: : (?<format> [^][{}]+ ) )? (?(1) \] | }} ) /sx';
+		$output_regex = '/ (?: ( \[ ) | ( {{ ) | ( \|\| ) ) api4: (?<field> [^][[:space:]:{}]+ (?::(?:label|value|name|id))?) (?: : (?<format> [^][{}]+ ) )? (?(1) \] | (?(2) (?: }}) | (?: \|\|) ) ) /sx';
 
 		if ( preg_match_all( $output_regex, $content, $match ) ) {
 			$params['select'] = array_values( $match['field'] );


### PR DESCRIPTION
Some elementor elements such as buttons wipe out the curly braces from `{{api4:id}}` in urls.

This adds `||api4:id||` as valid syntax to swap out for the id, which allows for ux shortcodes to be better used in urls/other elementor elements