### PR TITLE
Fix 'register_rest_route was called incorrectly'

### DIFF
--- a/includes/class-civicrm-ux-rest-manager.php
+++ b/includes/class-civicrm-ux-rest-manager.php
@@ -34,7 +34,8 @@ class Civicrm_Ux_REST_Manager extends Abstract_Civicrm_Ux_Module_Manager {
 				'callback' => [
 					$instance,
 					'rest_api_callback'
-				]
+				],
+				'permission_callback' => '__return_true',
 			] );
 		}
 	}


### PR DESCRIPTION
See https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/#permissions-callback