### PR TITLE
PHP array key warnings and strftime deprecation

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -55,7 +55,7 @@ The following example code can be inserted into a WordPress page when using the 
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><strong>Date:</strong> [api4:start_date:%B %E, %Y]</p>
+<p><strong>Date:</strong> [api4:start_date:F jS Y]</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
@@ -101,7 +101,7 @@ The following example code can be inserted into a WordPress page when using the 
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><strong>Date:</strong> [api4:start_date:%B %E, %Y]</p>
+<p><strong>Date:</strong> [api4:start_date:F jS Y]</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 

--- a/shortcodes/civicrm/api4-get.php
+++ b/shortcodes/civicrm/api4-get.php
@@ -160,7 +160,7 @@ class Civicrm_Ux_Shortcode_CiviCRM_Api4_Get extends Abstract_Civicrm_Ux_Shortcod
 					$field = $fields[ $match['field'] ] ?? [];
 
 					if ( ( $field['data_type'] == 'Date' ) || ( $field['data_type'] == 'Timestamp' ) ) {
-						$output = isset( $match['format'] ) ? strftime( $match['format'], strtotime( $output ) ) : CRM_Utils_Date::customFormat( $output );
+						$output = isset( $match['format'] ) ? date( $match['format'], strtotime( $output ) ) : CRM_Utils_Date::customFormat( $output );
 					} elseif ( $field['fk_entity'] == 'File' ) {
 						$output = Civicrm_Ux::in_basepage( function () use ( $output ) {
 							return htmlentities( civicrm_api3( 'Attachment', 'getvalue', [
@@ -179,7 +179,7 @@ class Civicrm_Ux_Shortcode_CiviCRM_Api4_Get extends Abstract_Civicrm_Ux_Shortcod
 						if ( is_array( $output ) ) {
 							$output = implode( ', ', $output );
 						}
-						if ( strcasecmp( $match['format'], 'br' ) === 0 ) {
+						if ( strcasecmp( $match['format'] ?? '', 'br' ) === 0 ) {
 							$output .= '<br />';
 						}
 					}

--- a/shortcodes/civicrm/api4-get.php
+++ b/shortcodes/civicrm/api4-get.php
@@ -74,9 +74,14 @@ class Civicrm_Ux_Shortcode_CiviCRM_Api4_Get extends Abstract_Civicrm_Ux_Shortcod
 					$params['orderBy'][ $sort ] = $dir;
 					break;
 				default:
-					[ $op, $value ] = explode( ':', $v, 2 );
-					if ( ! $value ) {
-						$value = $op;
+					if (strpos($v, ':') !== false) {
+						[ $op, $value ] = explode( ':', $v, 2 );
+						if ( ! $value ) {
+							$value = $op;
+							$op    = '=';
+						}
+					} else {
+						$value = $v;
 						$op    = '=';
 					}
 
@@ -129,7 +134,7 @@ class Civicrm_Ux_Shortcode_CiviCRM_Api4_Get extends Abstract_Civicrm_Ux_Shortcod
 
 			$trkey = $this->get_shortcode_name() . '__' . $post_revision . md5( $atts['entity'] . ':get:' . json_encode( $params ) );
 
-			$all = $_GET['reset'] ? FALSE : get_transient( $trkey );
+			$all = ($_GET['reset'] ?? FALSE) ? FALSE : get_transient( $trkey );
 
 			if ( $all !== FALSE ) {
 				return $all;


### PR DESCRIPTION
Fixed some PHP missing array key warnings due to lazy coding, and switched from strftime() to date() (including formatting examples in USAGE.md) because the former is deprecated.