### PR TITLE
get rid of PHP warning for set_title

### DIFF
--- a/includes/class-civicrm-ux.php
+++ b/includes/class-civicrm-ux.php
@@ -327,7 +327,7 @@ class Civicrm_Ux {
 		global $civicrm_wp_title;
 		global $post;
 
-		if ( $tag == 'civicrm' && $attr['set_title'] && ! empty( $civicrm_wp_title ) ) {
+		if ( $tag == 'civicrm' && ( $attr['set_title'] ?? false ) && ! empty( $civicrm_wp_title ) ) {
 			$post->post_title = $civicrm_wp_title;
 
 			add_filter( 'single_post_title', [


### PR DESCRIPTION
Was seeing warnings like:
`PHP Warning:  Undefined array key "set_title"`
in PHP 8.0 and PHP 8.1 with CiviCRM 5.67.1 (but also earlier).