### PR TITLE
Fix string interpolation

### DIFF
--- a/shortcodes/civicrm/api4-get.php
+++ b/shortcodes/civicrm/api4-get.php
@@ -187,7 +187,7 @@ class Civicrm_Ux_Shortcode_CiviCRM_Api4_Get extends Abstract_Civicrm_Ux_Shortcod
 
 							if ( $output && preg_match( '/^img( : (?<w> \d+ %? ) x (?<h> \d+ %? ) | : alt= (?<alt>.*) | : [^:]* )* /x', $match['format'], $m ) ) {
 								$output = '<img src="' . $output . '"'
-								          . ( !empty($m['w']) ? " width=\"${m['w']}\" height=\"${m['h']}\"" : '' ) .
+								          . ( !empty($m['w']) ? " width=\"{$m['w']}\" height=\"{$m['h']}\"" : '' ) .
 								          ' alt="' . ( !empty($m['alt']) ? htmlentities( $m['alt'] ) : '" role="presentation' ) .
 								          '">';
 							}


### PR DESCRIPTION
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/wp-content/plugins/wp-civicrm-ux/shortcodes/civicrm/api4-get.php on line 190

```php
// before
${m['w']}

//after
{$m['w']}
```

```php
// before
${m['h']}

//after
{$m['h']}
```